### PR TITLE
Use fixed version of Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:focal
 
 RUN apt update -y && apt upgrade -y
 


### PR DESCRIPTION
Hi, there's a small issue in the Dockerfile. It's implicitly referencing `:latest` tag which has just been recently updated to Ubuntu 22.x (Jammy) and build is now failing because node v16 is not yet supported there.

This should get fixed soon but it's usually better idea not to reference floating tags like `latest` as this tends to break in time.

When set to `:focal` it builds correctly.

**Note**: sorry for the newline at the end of the file but was editing this from GH web and it always adds it. It shouldn't break anything but feel free to remove it.