### PR TITLE
Make compatible with idasen-controller 2.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt install bluez -y
 
 RUN apt install build-essential libglib2.0-dev libical-dev libreadline-dev libudev-dev libdbus-1-dev libdbus-glib-1-dev bluetooth libbluetooth-dev usbutils -y
 
-RUN pip3 install idasen-controller
+RUN pip3 install idasen-controller==2.0.0
 
 RUN apt install curl -y
 

--- a/index.js
+++ b/index.js
@@ -50,8 +50,8 @@ const connected$ = new Subject();
 connected$
   .pipe(
     tap(() => {
-      console.log('triggering monitor..');
-      spawn('idasen-controller', ['--forward', '--monitor']);
+      console.log('triggering watch..');
+      spawn('idasen-controller', ['--forward', '--watch']);
     })
   )
   .subscribe();
@@ -96,7 +96,7 @@ mqttDeskPositionCm$
           console.log(
             'Ping to get the height and make sure the desk appears as connected'
           );
-          spawn('idasen-controller', ['--forward', '--monitor']);
+          spawn('idasen-controller', ['--forward', '--watch']);
         }),
         repeat()
       )


### PR DESCRIPTION
idasen-controller 2.0.0 changed the command `--monitor` to `--watch` in [this commit](https://github.com/rhyst/idasen-controller/commit/cb89acc703d490629e9d908f4163d9a16a955a66), breaking heigh reporting in this project.

This PR simply fixes the internal references from monitor to watch and fixates the version of idasen-controller to 2.0.0 to prevent accidentally breaking whenever a new version is released.